### PR TITLE
Add Clarifaction in README.md , and  .github/ISSUE_TEMPLATE/game-compatibility-report.yml to NOT submit Xenia Manager logs 

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
@@ -71,7 +71,7 @@ body:
     type: textarea
     attributes:
       label: Log
-      description: 'Put xenia.log into a zip and drag it here. It will be either in the same directory as the game, or the config, (DO NOT put logs from Xenia Manager): https://github.com/xenia-canary/xenia-canary/wiki/Options#how-to-use'
+      description: 'Put xenia.log into a zip and drag it here. It will be either in the same directory as the game, or the config, (DO NOT submit logs from Xenia Manager): https://github.com/xenia-canary/xenia-canary/wiki/Options#how-to-use'
       placeholder: '![xenia.log.zip](url)'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
@@ -71,7 +71,7 @@ body:
     type: textarea
     attributes:
       label: Log
-      description: 'Put xenia.log into a zip and drag it here. It will be either in the same directory as the game, or the config: https://github.com/xenia-canary/xenia-canary/wiki/Options#how-to-use'
+      description: 'Put xenia.log into a zip and drag it here. It will be either in the same directory as the game, or the config, (DO NOT put logs from Xenia Manager): https://github.com/xenia-canary/xenia-canary/wiki/Options#how-to-use'
       placeholder: '![xenia.log.zip](url)'
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-  * Xenia Manager Logs instead of logs directly from canary. 
+  * Xenia Manager Logs instead of logs directly from Xenia Canary. 
     * Xenia Manager log - Log-20260121, Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-  * (THIS IS ONLY FOR XENIA MANAGER USERS) Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121,
-  * Xenia Canary log - xenia.log
+    * Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121
+  * Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`
     * `How do I get games?`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-  * Xenia Manager Logs instead of logs directly from Xenia Canary. 
+  * [Xenia Manager](https://github.com/xenia-manager/xenia-manager) Logs instead of logs directly from Xenia Canary. 
     * Xenia Manager log - Log-20260121, Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compatibility Report template, or else your issue will be closed.
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
   * Xenia Manager Logs instead of logs directly from canary. 
-    * Xenia Manager log - Log-20260121 Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
+    * Xenia Manager log - Log-20260121, Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`
     * `How do I get games?`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-  * (IF YOUR USING XENIA MANAGER READ THIS) Xenia Manger Logs instead of logs directly from canary, Xenia Manager log - Log-20260121,
+  * (THIS IS ONLY FOR XENIA MANAGER USERS) Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121,
   * Xenia Canary log - xenia.log
   * Tech Support:
     * `How do I do/fix X?`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
+  * (IF YOUR USING XENIA MANAGER READ THIS) Xenia Manger Logs instead of logs directly from canary, Xenia Manager log - Log-20260121,
+  * Xenia Canary log - xenia.log
   * Tech Support:
     * `How do I do/fix X?`
     * `How do I get games?`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-  * Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121
-    * Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
+  * Xenia Manager Logs instead of logs directly from canary. 
+    * Xenia Manager log - Log-20260121 Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`
     * `How do I get games?`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Compatibility Report template, or else your issue will be closed.
   * Non-game-specific Xenia issue(s).
   * Results not from [Xenia Canary](https://github.com/xenia-canary/xenia-canary/releases/download/experimental/xenia_canary.zip).
     * Results from Xenia master belong in its own [compatibility tracker](https://github.com/xenia-project/game-compatibility/issues).
-    * Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121
-  * Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
+  * Xenia Manager Logs instead of logs directly from canary, Xenia Manager log - Log-20260121
+    * Xenia Canary log - xenia.log (If your not using Xenia Manager don't worry about this)
   * Tech Support:
     * `How do I do/fix X?`
     * `How do I get games?`


### PR DESCRIPTION
This helps make sure logs submitted in compatibility reports are from Xenia Canary and not from Xenia Manager.

Before 
<img width="1199" height="315" alt="Screenshot 2026-01-26 232919" src="https://github.com/user-attachments/assets/894c78ae-220f-4b47-b6df-1a5d504c7060" />

<img width="1221" height="335" alt="Screenshot 2026-01-26 232902" src="https://github.com/user-attachments/assets/a1009091-8e92-4ac1-b4e1-61a17ace42bd" />

After 
<img width="1211" height="315" alt="Screenshot 2026-01-26 233022" src="https://github.com/user-attachments/assets/b36dec62-0419-44f7-a17a-e383f384212c" />

<img width="1205" height="403" alt="Screenshot 2026-01-26 233004" src="https://github.com/user-attachments/assets/e025d3f8-ee4f-449c-89b7-e48fc2925934" />
