### PR TITLE
Compatibility report update

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
@@ -83,19 +83,24 @@ body:
       placeholder: '![Screenshot](url)'
     validations:
       required: true
-  - id: labels
-    type: input
+  - id: state-label
+    type: dropdown
     attributes:
-      label: Labels
+      label: State
       description: |
-        See https://github.com/xenia-canary/game-compatibility/labels
-        Labels you shouldn't use:
-          * issue-invalid
-          * issue-duplicate
-          * issue-superseded
-          * issue-cluttered
-
-        Each label must be separated by a comma.
-      placeholder: state-intro, gpu-drawing-corrupt
+        Select the state that best describes the game's current functionality.
+        See https://github.com/xenia-canary/game-compatibility/labels?q=state
+      options:
+        - Nothing
+        - Crash (Host)
+        - Crash (Guest)
+        - Crash (XNA)
+        - Hang
+        - Intro
+        - Title
+        - Load
+        - Menus
+        - Gameplay
+        - Playable
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility-report.yml
@@ -89,7 +89,7 @@ body:
       label: State
       description: |
         Select the state that best describes the game's current functionality.
-        See https://github.com/xenia-canary/game-compatibility/labels?q=state
+        See https://github.com/xenia-canary/game-compatibility/labels?q=state for comments
       options:
         - Nothing
         - Crash (Host)
@@ -104,3 +104,18 @@ body:
         - Playable
     validations:
       required: true
+  - id: additional-labels
+    type: input
+    attributes:
+      label: Additional Labels
+      description: |
+        See https://github.com/xenia-canary/game-compatibility/labels
+        Labels you shouldn't use:
+          * issue-invalid
+          * issue-duplicate
+          * issue-superseded
+          * issue-cluttered
+          * state-\* (use the State dropdown above)
+
+        Each label must be separated by a comma.
+      placeholder: gpu-drawing-corrupt, apu-garbage


### PR DESCRIPTION
Replaced the old `Labels` input with a dropdown for `State` labels and input for `Additional Labels` such as tech used and other labels not related to state